### PR TITLE
[Feature] Implement Clock-In, Clock-Out and Index on Sleep Record endpoints

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-
-  private
-
-  def set_current_user
-    user_id = request.headers["X-User-Id"]
-    render json: { error: "X-User-Id header missing" }, status: :unauthorized and return unless user_id.present?
-
-    @current_user = User.find_by(id: user_id)
-    render json: { error: "Current user not found" }, status: :unauthorized and return if @current_user.nil?
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+
+  def set_current_user
+    user_id = request.headers["X-User-Id"]
+    render json: { error: "X-User-Id header missing" }, status: :unauthorized and return unless user_id.present?
+
+    @current_user = User.find_by(id: user_id)
+    render json: { error: "Current user not found" }, status: :unauthorized and return if @current_user.nil?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+
+  # TODO: Implement a proper authentication mechanism
+  def set_current_user
+    user_id = request.headers["X-User-Id"]
+    render json: { error: "X-User-Id header missing" }, status: :unauthorized and return unless user_id.present?
+
+    @current_user = User.find_by(id: user_id)
+    render json: { error: "Current user not found" }, status: :unauthorized and return if @current_user.nil?
+  end
 end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -33,15 +33,6 @@ class FollowsController < ApplicationController
 
   private
 
-  # TODO: Implement a proper authentication mechanism
-  def set_current_user
-    user_id = request.headers["X-User-Id"]
-    render json: { error: "X-User-Id header missing" }, status: :unauthorized and return unless user_id.present?
-
-    @current_user = User.find_by(id: user_id)
-    render json: { error: "Current user not found" }, status: :unauthorized and return if @current_user.nil?
-  end
-
   def set_user_to_follow
     @user_to_follow = User.find_by(id: params[:id])
     unless @user_to_follow

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -14,16 +14,11 @@ class SleepRecordController < ApplicationController
 
   # PUT /sleep_records/clock_out
   def clock_out
-    sleep_record = @current_user.sleep_records.where(clock_out: nil).order(:clock_in).last
-    if sleep_record.nil?
-      return render json: { error: "No active sleep session found" }, status: :not_found
-    end
-
-    sleep_record.clock_out = Time.current
-    if sleep_record.save
-      render json: sleep_record, status: :ok
+    result = SleepRecordUsecase::ClockOut.new(@current_user).call
+    if result.success?
+      render json: result.sleep_record, status: :ok
     else
-      render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
+      render json: { error: result.error }, status: :bad_request
     end
   end
 

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -6,7 +6,7 @@ class SleepRecordController < ApplicationController
   def clock_in
     result = SleepRecordUsecase::ClockIn.new(@current_user).call
     if result.success?
-      render json: result.sleep_record, status: :created
+      render json: result.data, status: :created
     else
       render json: { error: result.error }, status: :bad_request
     end
@@ -16,7 +16,7 @@ class SleepRecordController < ApplicationController
   def clock_out
     result = SleepRecordUsecase::ClockOut.new(@current_user).call
     if result.success?
-      render json: result.sleep_record, status: :ok
+      render json: result.data, status: :ok
     else
       render json: { error: result.error }, status: :bad_request
     end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -32,4 +32,12 @@ class SleepRecordController < ApplicationController
       render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
     end
   end
+
+  def index
+    follower_ids = @current_user.active_follows.pluck(:followed_id)
+    follower_ids << @current_user.id # Include self
+    sleep_records = SleepRecord.where(user_id: follower_ids).order(clock_in: :desc)
+
+    render json: sleep_records, status: :ok
+  end
 end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -1,0 +1,3 @@
+class SleepRecordController < ApplicationController
+  before_action :set_current_user
+end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -5,29 +5,35 @@ class SleepRecordController < ApplicationController
   # POST /sleep_records/clock_in
   def clock_in
     result = SleepRecordUsecase::ClockIn.new(@current_user).call
-    if result.success?
-      render json: result.data, status: :created
-    else
-      render json: { error: result.error }, status: :bad_request
-    end
+    render_result(result, :created)
   end
 
   # PUT /sleep_records/clock_out
   def clock_out
     result = SleepRecordUsecase::ClockOut.new(@current_user).call
-    if result.success?
-      render json: result.data, status: :ok
-    else
-      render json: { error: result.error }, status: :bad_request
-    end
+    render_result(result, :ok)
   end
 
   def index
-    include_followers = params[:include_followers] == "true"
+    result = SleepRecordUsecase::List.new(
+      @current_user,
+      include_followers: index_params[:include_followers]
+    ).call
 
-    result = SleepRecordUsecase::List.new(@current_user, include_followers: include_followers).call
+    render_result(result, :ok)
+  end
+
+  private
+
+  def index_params
+    params.permit(:include_followers).tap do |params|
+      params[:include_followers] = params[:include_followers] == "true"
+    end
+  end
+
+  def render_result(result, success_status)
     if result.success?
-      render json: result.data, status: :ok
+      render json: result.data, status: success_status
     else
       render json: { error: result.error }, status: :bad_request
     end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -2,7 +2,7 @@ class SleepRecordController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :set_current_user
 
-  # POST /sleep-records/sleep
+  # POST /sleep_records/clock_in
   def clock_in
     # Check if an active session exists
     active_session = @current_user.sleep_records.find_by(clock_out: nil)
@@ -13,6 +13,21 @@ class SleepRecordController < ApplicationController
     sleep_record = @current_user.sleep_records.new(clock_in: Time.current)
     if sleep_record.save
       render json: sleep_record, status: :created
+    else
+      render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PUT /sleep_records/clock_out
+  def clock_out
+    sleep_record = @current_user.sleep_records.where(clock_out: nil).order(:clock_in).last
+    if sleep_record.nil?
+      return render json: { error: "No active sleep session found" }, status: :not_found
+    end
+
+    sleep_record.clock_out = Time.current
+    if sleep_record.save
+      render json: sleep_record, status: :ok
     else
       render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -23,10 +23,13 @@ class SleepRecordController < ApplicationController
   end
 
   def index
-    follower_ids = @current_user.active_follows.pluck(:followed_id)
-    follower_ids << @current_user.id # Include self
-    sleep_records = SleepRecord.where(user_id: follower_ids).order(clock_in: :desc)
+    include_followers = params[:include_followers] == "true"
 
-    render json: sleep_records, status: :ok
+    result = SleepRecordUsecase::List.new(@current_user, include_followers: include_followers).call
+    if result.success?
+      render json: result.data, status: :ok
+    else
+      render json: { error: result.error }, status: :bad_request
+    end
   end
 end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -1,4 +1,20 @@
 class SleepRecordController < ApplicationController
   skip_before_action :verify_authenticity_token
   before_action :set_current_user
+
+  # POST /sleep-records/sleep
+  def clock_in
+    # Check if an active session exists
+    active_session = @current_user.sleep_records.find_by(clock_out: nil)
+    if active_session
+      render json: { error: "You already have an active sleep session" }, status: :bad_request and return
+    end
+
+    sleep_record = @current_user.sleep_records.new(clock_in: Time.current)
+    if sleep_record.save
+      render json: sleep_record, status: :created
+    else
+      render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
 end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -1,3 +1,4 @@
 class SleepRecordController < ApplicationController
+  skip_before_action :verify_authenticity_token
   before_action :set_current_user
 end

--- a/app/controllers/sleep_record_controller.rb
+++ b/app/controllers/sleep_record_controller.rb
@@ -4,17 +4,11 @@ class SleepRecordController < ApplicationController
 
   # POST /sleep_records/clock_in
   def clock_in
-    # Check if an active session exists
-    active_session = @current_user.sleep_records.find_by(clock_out: nil)
-    if active_session
-      render json: { error: "You already have an active sleep session" }, status: :bad_request and return
-    end
-
-    sleep_record = @current_user.sleep_records.new(clock_in: Time.current)
-    if sleep_record.save
-      render json: sleep_record, status: :created
+    result = SleepRecordUsecase::ClockIn.new(@current_user).call
+    if result.success?
+      render json: result.sleep_record, status: :created
     else
-      render json: { errors: sleep_record.errors.full_messages }, status: :unprocessable_entity
+      render json: { error: result.error }, status: :bad_request
     end
   end
 

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -1,0 +1,3 @@
+class SleepRecord < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -3,4 +3,15 @@ class SleepRecord < ApplicationRecord
 
   # Validate presence of clock_in (clock_out can be nil when still sleeping)
   validates :clock_in, presence: true
+
+  # Custom validation to prevent overlapping active sleep records per user
+  validate :no_overlapping_active_sessions, on: :create
+
+  private
+
+  def no_overlapping_active_sessions
+    if SleepRecord.where(user_id: user_id, clock_out: nil).exists?
+      errors.add(:base, "You already have an active sleep session")
+    end
+  end
 end

--- a/app/models/sleep_record.rb
+++ b/app/models/sleep_record.rb
@@ -1,3 +1,6 @@
 class SleepRecord < ApplicationRecord
   belongs_to :user
+
+  # Validate presence of clock_in (clock_out can be nil when still sleeping)
+  validates :clock_in, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,6 @@ class User < ApplicationRecord
   # Users who follow me
   has_many :passive_follows, class_name: "Follow", foreign_key: "followed_id", dependent: :destroy
   has_many :followers, through: :passive_follows, source: :follower
+
+  has_many :sleep_records, dependent: :destroy
 end

--- a/app/repositories/sleep_record_repository.rb
+++ b/app/repositories/sleep_record_repository.rb
@@ -1,0 +1,35 @@
+class SleepRecordRepository
+  def list(user_ids)
+    SleepRecord.where(user_id: user_ids).order(clock_in: :desc)
+  end
+
+  def find(id)
+    SleepRecord.find_by(id: id)
+  end
+
+  def find_active_by_user(user_id)
+    SleepRecord.where(user_id: user_id, clock_out: nil).order(:clock_in).last
+  end
+
+  def create(user_id:, clock_in:, clock_out: nil)
+    sleep_record = SleepRecord.new(
+      user_id: user_id,
+      clock_in: clock_in,
+      clock_out: clock_out
+    )
+    sleep_record.save ? sleep_record : nil
+  end
+
+  def update(id:, clock_in: nil, clock_out: nil)
+    sleep_record = SleepRecord.find_by(id: id)
+    return nil unless sleep_record
+
+    sleep_record.clock_in = clock_in if clock_in
+    sleep_record.clock_out = clock_out if clock_out
+    sleep_record.save ? sleep_record : nil
+  end
+
+  def delete(sleep_record)
+    sleep_record.destroy
+  end
+end

--- a/app/usecases/sleep_record_usecase/base.rb
+++ b/app/usecases/sleep_record_usecase/base.rb
@@ -15,7 +15,7 @@ module SleepRecordUsecase
     end
 
     def success(record)
-      OpenStruct.new(success?: true, sleep_record: record)
+      OpenStruct.new(success?: true, data: record)
     end
 
     def failure(error_message)

--- a/app/usecases/sleep_record_usecase/base.rb
+++ b/app/usecases/sleep_record_usecase/base.rb
@@ -1,0 +1,25 @@
+require "ostruct"
+
+module SleepRecordUsecase
+  class Base
+    def initialize(user)
+      @user = user
+    end
+
+    private
+
+    attr_reader :user
+
+    def get_active_session
+      @user.sleep_records.where(clock_out: nil).order(:clock_in).last
+    end
+
+    def success(record)
+      OpenStruct.new(success?: true, sleep_record: record)
+    end
+
+    def failure(error_message)
+      OpenStruct.new(success?: false, error: error_message)
+    end
+  end
+end

--- a/app/usecases/sleep_record_usecase/clock_in.rb
+++ b/app/usecases/sleep_record_usecase/clock_in.rb
@@ -1,0 +1,35 @@
+require "ostruct"
+
+module SleepRecordUsecase
+  class ClockIn
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      user = get_user
+      return failure("User not found") unless user
+
+      active_session = user.sleep_records.where(clock_out: nil).last
+      return failure("You already have an active sleep session") if active_session
+
+      record = user.sleep_records.new(clock_in: Time.current)
+
+      if record.save
+        success(record)
+      else
+        failure("Failed to create sleep record")
+      end
+    end
+
+    private
+
+    def success(record)
+      OpenStruct.new(success?: true, sleep_record: record)
+    end
+
+    def failure(error_message)
+      OpenStruct.new(success?: false, error: error_message)
+    end
+  end
+end

--- a/app/usecases/sleep_record_usecase/clock_in.rb
+++ b/app/usecases/sleep_record_usecase/clock_in.rb
@@ -7,13 +7,12 @@ module SleepRecordUsecase
     end
 
     def call
-      user = get_user
-      return failure("User not found") unless user
+      return failure("User not found") unless @user
 
-      active_session = user.sleep_records.where(clock_out: nil).last
+      active_session = @user.sleep_records.where(clock_out: nil).last
       return failure("You already have an active sleep session") if active_session
 
-      record = user.sleep_records.new(clock_in: Time.current)
+      record = @user.sleep_records.new(clock_in: Time.current)
 
       if record.save
         success(record)

--- a/app/usecases/sleep_record_usecase/clock_in.rb
+++ b/app/usecases/sleep_record_usecase/clock_in.rb
@@ -1,34 +1,25 @@
 require "ostruct"
 
 module SleepRecordUsecase
-  class ClockIn
+  class ClockIn < SleepRecordUsecase::Base
+    attr_reader :user, :sleep_record
     def initialize(user)
-      @user = user
+      super(user)
     end
 
     def call
       return failure("User not found") unless @user
 
-      active_session = @user.sleep_records.where(clock_out: nil).last
+      active_session = self.get_active_session
       return failure("You already have an active sleep session") if active_session
 
       record = @user.sleep_records.new(clock_in: Time.current)
 
       if record.save
-        success(record)
+        self.success(record)
       else
-        failure("Failed to create sleep record")
+        self.failure("Failed to create sleep record")
       end
-    end
-
-    private
-
-    def success(record)
-      OpenStruct.new(success?: true, sleep_record: record)
-    end
-
-    def failure(error_message)
-      OpenStruct.new(success?: false, error: error_message)
     end
   end
 end

--- a/app/usecases/sleep_record_usecase/clock_out.rb
+++ b/app/usecases/sleep_record_usecase/clock_out.rb
@@ -1,0 +1,25 @@
+require "ostruct"
+
+module SleepRecordUsecase
+  class ClockOut < Base
+    attr_reader :user, :sleep_record
+    def initialize(user)
+      super(user)
+    end
+
+    def call
+      return failure("User not found") unless @user
+
+      active_session = self.get_active_session
+      return failure("No active sleep session found") if active_session.nil?
+
+      active_session.clock_out = Time.current
+
+      if active_session.save
+        self.success(active_session)
+      else
+        self.failure("Failed to clock out")
+      end
+    end
+  end
+end

--- a/app/usecases/sleep_record_usecase/list.rb
+++ b/app/usecases/sleep_record_usecase/list.rb
@@ -1,0 +1,31 @@
+module SleepRecordUsecase
+  class List < Base
+    def initialize(user, include_followers: false)
+      super(user)
+      @include_followers = include_followers
+    end
+
+    def call
+      return failure("User not found") unless @user
+
+      follower_ids = get_follower_ids
+      sleep_records = SleepRecord.where(user_id: follower_ids).order(clock_in: :desc)
+
+      if sleep_records.any?
+        success(sleep_records)
+      else
+        failure("No sleep records found")
+      end
+    end
+
+    private
+
+    def get_follower_ids
+      return [ @user.id ] unless @include_followers
+
+      follower_ids = @user.active_follows.pluck(:followed_id)
+      follower_ids << @user.id
+      follower_ids
+    end
+  end
+end

--- a/app/usecases/sleep_record_usecase/list.rb
+++ b/app/usecases/sleep_record_usecase/list.rb
@@ -11,11 +11,7 @@ module SleepRecordUsecase
       follower_ids = get_follower_ids
       sleep_records = SleepRecord.where(user_id: follower_ids).order(clock_in: :desc)
 
-      if sleep_records.any?
-        success(sleep_records)
-      else
-        failure("No sleep records found")
-      end
+      success(sleep_records)
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,5 @@ Rails.application.routes.draw do
   put "users/:id/follow",   to: "follows#follow",   as: :follow_user
   put "users/:id/unfollow", to: "follows#unfollow",  as: :unfollow_user
 
-  # Defines the root path route ("/")
-  # root "posts#index"
+  post "/sleep_records/clock_in", to: "sleep_record#clock_in", as: :clock_in
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   put "users/:id/unfollow", to: "follows#unfollow",  as: :unfollow_user
 
   post "/sleep_records/clock_in", to: "sleep_record#clock_in", as: :clock_in
+  put "/sleep_records/clock_out", to: "sleep_record#clock_out", as: :clock_out
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
 
   post "/sleep_records/clock_in", to: "sleep_record#clock_in", as: :clock_in
   put "/sleep_records/clock_out", to: "sleep_record#clock_out", as: :clock_out
+  get "/sleep_records", to: "sleep_record#index", as: :sleep_records
 end

--- a/db/migrate/20250523085826_create_sleep_records.rb
+++ b/db/migrate/20250523085826_create_sleep_records.rb
@@ -1,0 +1,11 @@
+class CreateSleepRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :sleep_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.datetime :clock_in, null: false
+      t.datetime :clock_out
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_23_062732) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_23_085826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_23_062732) do
     t.index ["follower_id"], name: "index_follows_on_follower_id"
   end
 
+  create_table "sleep_records", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "clock_in"
+    t.datetime "clock_out"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sleep_records_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -30,4 +39,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_23_062732) do
 
   add_foreign_key "follows", "users", column: "followed_id"
   add_foreign_key "follows", "users", column: "follower_id"
+  add_foreign_key "sleep_records", "users"
 end

--- a/spec/models/sleep_record_spec.rb
+++ b/spec/models/sleep_record_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SleepRecord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Description
- Implement sleep record clock-in endpoint
- Implement sleep record clock-out endpoint
- Implement sleep record list endpoint
- Implement the use-case layer as the first step of clean architecture

## Self Test
### Clock-In
#### Success - Open an active sleep session
<img width="1334" alt="Screenshot 2025-05-25 at 01 59 43" src="https://github.com/user-attachments/assets/da8dfa8a-8ab9-478c-9788-493065317653" />

#### Failure - Already have an active sleep session
<img width="1330" alt="Screenshot 2025-05-25 at 01 59 50" src="https://github.com/user-attachments/assets/a2b2d819-e3a7-431f-b555-6922c8064bcc" />

### Clock-Out
#### Success - Close an active sleep session
<img width="1341" alt="Screenshot 2025-05-25 at 02 00 07" src="https://github.com/user-attachments/assets/1333a424-e9b0-485f-914a-763a4373cbd6" />

#### Failure - No active sleep session found
<img width="1334" alt="Screenshot 2025-05-25 at 02 00 15" src="https://github.com/user-attachments/assets/7f5cd654-b3bc-4729-839c-7caa1fbbb586" />

### List
#### Success - List sleep records without follower's
<img width="1327" alt="Screenshot 2025-05-25 at 02 01 28" src="https://github.com/user-attachments/assets/2e169dec-8bed-457b-80fa-dbf58a10b6f8" />

#### Success - List sleep records with follower's
<img width="1321" alt="Screenshot 2025-05-25 at 02 01 53" src="https://github.com/user-attachments/assets/ceccb7ca-57ca-496b-a9fa-1e95ccda48ef" />

#### Success - No sleep records
<img width="1330" alt="Screenshot 2025-05-25 at 02 02 50" src="https://github.com/user-attachments/assets/00e9de46-31af-417c-9b91-c802c0a15bb3" />

#### Success - No sleep records - with followers
<img width="1328" alt="Screenshot 2025-05-25 at 02 03 06" src="https://github.com/user-attachments/assets/9b2e54a4-47b1-4fab-8080-234c661153f9" />
